### PR TITLE
Use the memcached extension by default

### DIFF
--- a/src/config/defaults/memcache.php
+++ b/src/config/defaults/memcache.php
@@ -51,7 +51,7 @@ return [
      *
      * If false [memcache](http://pecl.php.net/package/memcache). will be used.
      *
-     * Defaults to false.
+     * Defaults to true, since the memcached extension has support for PHP 7 
      */
-    'useMemcached' => false,
+    'useMemcached' => true,
 ];


### PR DESCRIPTION
The memcache (without d) extension has no support for PHP 7, the last release date 2013-04-07.

However, there  is a `php7` branch for memcached (with d): https://github.com/php-memcached-dev/php-memcached/tree/php7. 

There is no official 3.0.0 stable release on pecl.php.net yet, but this [commit looks promising](https://github.com/php-memcached-dev/php-memcached/commit/7a3b50992c5f68ed07132b6780128b3c7a1295e8): 